### PR TITLE
currentClass wird nun nur in der Tab-Navigation angepasst

### DIFF
--- a/js/jquery.tabs.js
+++ b/js/jquery.tabs.js
@@ -134,7 +134,7 @@
                 $(el)[positions[o.options.position]]('<ul class="clearfix '+o.options.tabsListClass+' tabamount'+tabCount+'">'+list+'</ul>');
                 $(el).find(o.options.tabbody).hide();
                 $(el).find(o.options.tabbody+':first').show();
-                $(el).find("ul>li:first").addClass(o.options.currentClass)
+                $(el).find("ul."+o.options.tabsListClass+">li:first").addClass(o.options.currentClass)
                 .find('a')[o.options.currentInfoPosition]('<span class="'+o.options.currentInfoClass+'">'+o.options.currentInfoText+'</span>');
                 
                 $(el).find('ul.'+o.options.tabsListClass+'>li>a').each(function(i){
@@ -144,7 +144,7 @@
                         if(o.options.saveState && $.cookie){
                             $.cookie('accessibletab_'+el.attr('id')+'_active',i);
                         }
-                        $(el).find('ul>li.'+o.options.currentClass).removeClass(o.options.currentClass)
+                        $(el).find('ul.'+o.options.tabsListClass+'>li.'+o.options.currentClass).removeClass(o.options.currentClass)
                         .find("span."+o.options.currentInfoClass).remove();
                         $(this).blur();
                         $(el).find(o.options.tabbody+':visible').hide();


### PR DESCRIPTION
Hallo Dirk,

ich hatte bei mir das Problem, dass innerhalb der Tabs auch Klassen wie z.B. current oder active vorkamen, welche wiederum an ein LI gebunden waren. Leider wurden diese Klassen im tabbody auch entfernt, obwohl dies nur für die Navigation vorgesehen ist.
Es sind demnach auch nur zwei Zeilen.

Viele Grüße
Michael
