### PR TITLE
Bug when using cssClassAvailable and only some items have classes

### DIFF
--- a/js/jquery.tabs.js
+++ b/js/jquery.tabs.js
@@ -141,8 +141,8 @@
                         if($(this).attr('class')) {
                             cssClass = $(this).attr('class');
                             cssClass = ' class="'+cssClass+'"';
-                            list += '<li id="'+navItemId+'"><a'+id+''+cssClass+' href="#'+tabId+'">'+$(this).html()+'</a></li>';
                         }
+                        list += '<li id="'+navItemId+'"><a'+id+''+cssClass+' href="#'+tabId+'">'+$(this).html()+'</a></li>';
                     } else {
                       list += '<li id="'+navItemId+'"><a'+id+' href="#'+tabId+'">'+$(this).html()+'</a></li>';
                     }


### PR DESCRIPTION
Currently, when `cssClassAvailable` is true, all of the `tabhead` elements have to have classes or they won't get pulled out into tabs. This commit fixes this assumption, as I only want classes on some elements.
